### PR TITLE
Add customizable messages and settings

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,0 +1,25 @@
+messages:
+  camera-on: "&aKamera-Modus aktiviert! Nutze /cam erneut zum Beenden."
+  camera-off: "&aKamera-Modus beendet."
+  no-permission: "&cDu hast keine Berechtigung, diesen Befehl zu verwenden."
+  no-player: "&cDieser Befehl kann nur von Spielern verwendet werden."
+  distance-limit: "&cDu kannst dich nicht weiter als {distance} Blöcke von deinem Körper entfernen!"
+  body-attacked: "&cDein Körper wurde von {damager} angegriffen! Kamera-Modus beendet."
+  body-env-damage: "&cDein Körper wurde durch Umweltschaden verletzt! Kamera-Modus beendet."
+  body-suffocating: "&cDein Körper erstickt! Kamera-Modus wird beendet."
+  body-drowning: "&cDein Körper ertrinkt!"
+  cant-fly-in-lava: "&cDu kannst nicht durch Lava fliegen! Kamera-Modus wird beendet."
+  no-projectiles: "&cDu kannst im Kamera-Modus keine Projektile verwenden."
+  cant-manipulate-other: "&cDu kannst den Körper eines anderen Spielers nicht manipulieren!"
+  cant-interact-other: "&cDu kannst mit dem Körper eines anderen Spielers nicht interagieren!"
+  armorstand.name-format: "&e{player}'s Körper"
+  hitbox.name-format: "&c[HITBOX] {player}"
+
+camera-mode:
+  max-distance: 100.0
+  distance-warning-cooldown: 3
+  drowning-damage: 2.0
+
+armorstand.name-visible: true
+armorstand.visible: true
+armorstand.gravity: true


### PR DESCRIPTION
## Summary
- add a default `config.yml` with messages and gameplay settings
- load configuration on startup
- use config values for messages and camera mode limits
- apply armor stand settings from config

## Testing
- `mvn -q -e -DskipTests package` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865661ed370832290b80ba9bc5b505e